### PR TITLE
Flatten and inflate arrays

### DIFF
--- a/src/Objects.test.ts
+++ b/src/Objects.test.ts
@@ -6,6 +6,7 @@ import {
   extract,
   flatten,
   getMutation,
+  inflate,
   mutate,
   objectContaining,
   objectContains,
@@ -69,6 +70,9 @@ describe("Objects", () => {
     describe("arrayize", () => {
       it("should return a list of property values", () => {
         expect(arrayize(null)).toEqual([["", null]])
+        expect(arrayize(1)).toEqual([["", 1]])
+        const date = new Date()
+        expect(arrayize(date)).toEqual([["", date]])
         expect(arrayize({ a: 1 })).toEqual([["a", 1]])
         expect(arrayize({ a: 1, b: { c: 2 } })).toEqual([
           ["a", 1],
@@ -84,17 +88,35 @@ describe("Objects", () => {
         const date = new Date()
         expect(arrayize({ a: date })).toEqual([["a", date]])
       })
+
+      it("should arrayize arrays", () => {
+        expect(arrayize([3, 2, 1])).toEqual([
+          ["0", 3],
+          ["1", 2],
+          ["2", 1],
+        ])
+      })
     })
 
     describe("flatten", () => {
       it("should return a flat object with all values", () => {
         const date = new Date()
         expect(flatten(null)).toEqual({ "": null })
+        expect(flatten(42)).toEqual({ "": 42 })
         expect(flatten({ a: undefined })).toEqual({ a: undefined })
         expect(flatten({ a: 1 })).toEqual({ a: 1 })
         expect(flatten({ a: date })).toEqual({ a: date })
         expect(flatten({ a: 1, b: { c: 2 } })).toEqual({ a: 1, "b.c": 2 })
         expect(flatten({ a: { b: 1 }, b: { a: 2 } })).toEqual({ "a.b": 1, "b.a": 2 })
+        expect(flatten([3, 2, 1])).toEqual({ "0": 3, "1": 2, "2": 1 })
+        expect(flatten({ a: [3, 2, { b: 1 }] })).toEqual({ "a.0": 3, "a.1": 2, "a.2.b": 1 })
+      })
+    })
+
+    describe("inflate", () => {
+      it("should inflate flattened data correctly", () => {
+        const data = { a: { b: [3, 2, 1], c: true, d: new Date() } }
+        expect(inflate(flatten(data))).toEqual(data)
       })
     })
   })
@@ -115,7 +137,7 @@ describe("Objects", () => {
 
   describe("objectContaining()", () => {
     it("should return an object containing an asymmetricMatch() function", () => {
-      const matcher = objectContaining({ a: 1 })
+      const matcher = objectContaining({ a: 1 } as Record<string, unknown>)
       expect(matcher).toBeInstanceOf(Object)
       expect(matcher).toHaveProperty("asymmetricMatch")
       expect(matcher.asymmetricMatch({ a: 1 })).toBe(true)

--- a/src/streams/KafkaSource.ts
+++ b/src/streams/KafkaSource.ts
@@ -35,9 +35,10 @@ export async function createKafkaSource<T>(
 
   async function run() {
     await consumer.run({
-      eachMessage: async ({ message, partition }) => {
+      eachMessage: ({ message, partition }) => {
         stream.push(JSON.parse(message.value?.toString() as string) as T)
         offsetProvider.setOffset(partition, message.offset)
+        return Promise.resolve()
       },
     })
 
@@ -76,12 +77,12 @@ export async function createKafkaSource<T>(
     return new Promise(resolve => {
       const resetTimer = startLater(resolve, headStartMs)
       stream
-        .on("data", data => {
+        .on("data", (data: T) => {
           processFn(data)
           resetTimer()
         })
         .on("error", console.error)
-      run()
+      void run()
     })
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,17 @@
-export type BaseType = string | number | boolean | null | undefined | Date
-export interface StringIndexableObject {
-  [property: string]: BaseType | StringIndexableObject
-}
-export type Arrayized = [string, BaseType]
+export type PathValue = Record<string, unknown>
+
+export type NestedValue<T extends string> = T extends `${infer K}.${infer Rest}`
+  ? K extends `${number}`
+    ? NestedArray<Rest>
+    : { [key in K]: NestedValue<Rest> }
+  : T extends `${number}`
+    ? unknown[]
+    : unknown
+
+export type NestedArray<T extends string> = T extends `${infer K}.${infer Rest}`
+  ? K extends `${number}`
+    ? NestedArray<Rest>[]
+    : { [key in K]: NestedValue<Rest> }[]
+  : unknown[]
+
+export type Arrayized = [string, unknown]


### PR DESCRIPTION
Previously, arrays were flattened with a numeric value as the key for each of their elements, but were inflated as objects with the numeric values as strings as their key.
With this change, this changes, making arrays flattened and inflated again to the same type, even if contained in a deeper part of an object.